### PR TITLE
Fix array types with non-f64 element types

### DIFF
--- a/src/template/array.rs
+++ b/src/template/array.rs
@@ -11,6 +11,7 @@ pub fn template(typ: &ArrayType) -> TokenStream {
     let fn_shape_name = typ.fn_shape_ident();
     let fn_values_name = typ.fn_values_ident();
     let fn_free_name = typ.fn_free_ident();
+    let elem_typ_name = typ.elements_type.ident();
 
     let summary_doc = format!(
         "Array of type `{}` and rank `{}`.",
@@ -38,7 +39,7 @@ pub fn template(typ: &ArrayType) -> TokenStream {
             ///
             ///  Multi-dimensional arrays are expect row-major form.
             #[allow(clippy::identity_op)]
-            pub fn new(context: &'c Context<B>, data: &[f64], #(#dim_params: usize),*) -> Self {
+            pub fn new(context: &'c Context<B>, data: &[#elem_typ_name], #(#dim_params: usize),*) -> Self {
                 assert_eq!(#(#dim_params *)* 1, data.len());
 
                 let inner = unsafe {
@@ -71,7 +72,7 @@ pub fn template(typ: &ArrayType) -> TokenStream {
             /// # Important
             /// Before calling this, you most likely want to call [`Context::sync`] first.
             /// See the documentation of [`Context::sync`] for more details.
-            pub fn values(&self, out: &mut Vec<f64>) {
+            pub fn values(&self, out: &mut Vec<#elem_typ_name>) {
                 let s = self.shape();
                 let len = s.iter().product::<usize>();
 

--- a/src/template/backend.rs
+++ b/src/template/backend.rs
@@ -251,6 +251,7 @@ fn impl_array_template(array: &ArrayType) -> TokenStream {
     let name_shape = array.fn_shape_ident();
     let name_values = array.fn_values_ident();
     let name_free = array.fn_free_ident();
+    let name_elem = array.elements_type.ident();
 
     let dims_new = (0..array.rank)
         .map(|i| format_ident!("dim_{}", i))
@@ -259,7 +260,7 @@ fn impl_array_template(array: &ArrayType) -> TokenStream {
     quote! {
         unsafe fn #name_new(
             ctx: *mut types::futhark_context,
-            data: *const f64,
+            data: *const #name_elem,
             #(#dims_new: i64),*
         ) -> *mut types::#name_type {
             sys::#name_new(ctx as *mut sys::futhark_context, data, #(#dims_new),*) as *mut types::#name_type
@@ -278,7 +279,7 @@ fn impl_array_template(array: &ArrayType) -> TokenStream {
         unsafe fn #name_values(
             ctx: *mut types::futhark_context,
             arr: *mut types::#name_type,
-            data: *mut f64,
+            data: *mut #name_elem,
         ) -> std::os::raw::c_int {
             sys::#name_values(
                 ctx as *mut sys::futhark_context,


### PR DESCRIPTION
When I try [gaussian-blur.fut](https://futhark-lang.org/examples/gaussian-blur.fut), I was getting below type mismatch error. It appears at couple of places, array element type was hardcoded as `f64` instead of being the same as defined in the template. This PR fixes those discrepancies.

```
error[E0053]: method `futhark_new_u8_3d` has an incompatible type for trait
   --> /workspaces/rust-nvidia-deepstream/target/debug/build/try-futhark-1b4cd244e1d94500/out/futhark/futhark_lib.rs:313:23
    |
313 |                 data: *const f64,
    |                       ^^^^^^^^^^
    |                       |
    |                       expected `u8`, found `f64`
    |                       help: change the parameter type to match the trait: `*const u8`
    |
note: type in trait
   --> /workspaces/rust-nvidia-deepstream/target/debug/build/try-futhark-1b4cd244e1d94500/out/futhark/futhark_lib.rs:204:19
    |
204 |             data: *const u8,
    |                   ^^^^^^^^^
    = note: expected signature `unsafe fn(_, *const u8, _, _, _) -> _`
               found signature `unsafe fn(_, *const f64, _, _, _) -> _`

error[E0053]: method `futhark_values_u8_3d` has an incompatible type for trait
   --> /workspaces/rust-nvidia-deepstream/target/debug/build/try-futhark-1b4cd244e1d94500/out/futhark/futhark_lib.rs:333:23
    |
333 |                 data: *mut f64,
    |                       ^^^^^^^^
    |                       |
    |                       expected `u8`, found `f64`
    |                       help: change the parameter type to match the trait: `*mut u8`
    |
```