### PR TITLE
Fix crash on wrong array size

### DIFF
--- a/src/template/array.rs
+++ b/src/template/array.rs
@@ -88,8 +88,10 @@ pub fn template(typ: &ArrayType) -> TokenStream {
 
         impl<B: Backend> Drop for #struct_name <'_, B> {
             fn drop(&mut self) {
-                unsafe {
-                    B::#fn_free_name(self.context.inner, self.inner);
+                if !self.inner.is_null() {
+                    unsafe {
+                        B::#fn_free_name(self.context.inner, self.inner);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Creating an array mismatched in size like `&rain::Array_U8_2D::new(&ctx, &[0;4], 1, 4),` where `(id_colors: [256][4]u8)` is expected would crash the entry function if that function returned an array. That's because the return value is not allocated on error.