### PR TITLE
RFC: Use named arguments in entry points

### DIFF
--- a/src/manifest/entry_point.rs
+++ b/src/manifest/entry_point.rs
@@ -1,12 +1,12 @@
 use proc_macro2::Ident;
 use quote::format_ident;
 
-use crate::manifest::Type;
+use crate::manifest::{Argument, Type};
 
 #[derive(Debug, Clone)]
 pub struct EntryPoint {
     pub name: String,
-    pub inputs: Vec<Type>,
+    pub inputs: Vec<Argument>,
     pub outputs: Vec<Type>,
 }
 

--- a/src/manifest/json.rs
+++ b/src/manifest/json.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use eyre::{bail, Context};
 use serde_json::{Map, Value};
 
-use crate::manifest::{ArrayType, EntryPoint, Manifest, Type, ValueType};
+use crate::manifest::{Argument, ArrayType, EntryPoint, Manifest, Type, ValueType};
 
 pub fn load(manifest_file_content: &str) -> eyre::Result<Manifest> {
     let json: serde_json::Value =
@@ -61,8 +61,13 @@ fn load_entry_point(
         .as_array()
         .unwrap()
         .iter()
-        .map(|input| input["type"].as_str().unwrap())
-        .map(|input_type| types[input_type])
+        .enumerate()
+        .map(|(i, input)| Argument {
+            name: input.get("name")
+                .map(|n| dbg!(dbg!(n).as_str().unwrap().into()))
+                .unwrap_or(format!("in_{}", i)),
+            type_: types[input["type"].as_str().unwrap()],
+        })
         .collect::<Vec<_>>();
 
     let outputs = obj["outputs"]

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -32,3 +32,8 @@ pub enum Type {
     Value(ValueType),
     Array(ArrayType),
 }
+#[derive(Debug, Clone)]
+pub struct Argument {
+    pub name: String,
+    pub type_: Type,
+}

--- a/src/template/backend.rs
+++ b/src/template/backend.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use crate::{
-    manifest::{ArrayType, EntryPoint, Manifest, Type},
+    manifest::{Argument, ArrayType, EntryPoint, Manifest, Type},
     Target,
 };
 
@@ -80,10 +80,10 @@ fn trait_array_template(array: &ArrayType) -> TokenStream {
 fn trait_entry_point_template(ep: &EntryPoint) -> TokenStream {
     let entry_name = ep.futhark_fn_ident();
 
-    let inputs = ep.inputs.iter().enumerate().map(|(i, typ)| {
-        let input_name = format_ident!("in_{}", i);
+    let inputs = ep.inputs.iter().map(|Argument{type_, name}| {
+        let input_name = format_ident!("{}", name);
 
-        match typ {
+        match type_ {
             Type::Value(value) => {
                 let type_name = value.ident();
                 quote!(#input_name: #type_name)
@@ -176,10 +176,10 @@ pub fn impl_template(manifest: &Manifest, backend: Target) -> TokenStream {
 fn impl_entry_point_template(ep: &EntryPoint) -> TokenStream {
     let entry_name = ep.futhark_fn_ident();
 
-    let rust_inputs = ep.inputs.iter().enumerate().map(|(i, typ)| {
-        let input_name = format_ident!("in_{}", i);
+    let rust_inputs = ep.inputs.iter().map(|Argument{type_, name}| {
+        let input_name = format_ident!("{}", name);
 
-        match typ {
+        match type_ {
             Type::Value(value) => {
                 let type_name = value.ident();
                 quote!(#input_name: #type_name)
@@ -206,10 +206,10 @@ fn impl_entry_point_template(ep: &EntryPoint) -> TokenStream {
         }
     });
 
-    let futhark_inputs = ep.inputs.iter().enumerate().map(|(i, typ)| {
-        let input_name = format_ident!("in_{}", i);
+    let futhark_inputs = ep.inputs.iter().map(|Argument{type_, name}| {
+        let input_name = format_ident!("{}", name);
 
-        match typ {
+        match type_ {
             Type::Value(_) => {
                 quote!(#input_name)
             }


### PR DESCRIPTION
This makes it easier to identify arguments in the called function on the Rust side.

I have not added any code that checks if the identifiers are syntactically valid.